### PR TITLE
#8 Change the entry point to src/index.js instead of built file

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "esn-api-client",
   "version": "0.0.1",
   "description": "JS library for OpenPaaS ESN APIs",
-  "main": "dist/esn-api-client.js",
+  "main": "src/index.js",
   "scripts": {
     "test": "jest",
     "lint": "eslint src test webpack.*.js",


### PR DESCRIPTION
Since we do not use Webpack to release, so the entry point of the library should point to src/index instead of a built file.