### PR TITLE
esn-api-client#12: Now allows passing a custom promise object when constructing the Client

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "esm": "^3.2.25",
     "jest": "^26.4.0",
     "path": "^0.12.7",
+    "promise-polyfill": "^8.1.3",
     "uglifyjs-webpack-plugin": "^2.2.0",
     "webpack": "^4.44.1",
     "webpack-cli": "^3.3.12",

--- a/src/Client.js
+++ b/src/Client.js
@@ -4,21 +4,34 @@ export default class Client {
   /**
    * @constructor
    * @param {Object} options An options object contains:
-   * @param {String} options.baseURL Base URL of your ESN server
-   * @param {String} options.auth    Auth strategy
+   * @param {String} options.baseURL        Base URL of your ESN server
+   * @param {String} options.auth           Auth strategy
+   * @param {Object=} options.customPromise A custom Promise object
    */
-  constructor({ baseURL, auth } = {}) {
+  constructor({ baseURL, auth, customPromise } = {}) {
     if (!baseURL) {
       throw new Error('baseURL is required');
     }
 
     this.httpClient = httpClient({ baseURL, auth });
+    this.customPromise = customPromise;
   }
 
   api(config) {
-    return this.httpClient({
-      withCredentials: true,
-      ...config
-    }).then(({ data }) => data);
+    if (!this.customPromise) {
+      return this.httpClient({
+        withCredentials: true,
+        ...config
+      }).then(({ data }) => data);
+    }
+
+    return this.customPromise((resolve, reject) => {
+      this.httpClient({
+        withCredentials: true,
+        ...config
+      })
+        .then(({ data }) => resolve(data))
+        .catch(reject);
+    });
   }
 }

--- a/test/Client.spec.js
+++ b/test/Client.spec.js
@@ -4,53 +4,57 @@ import httpClient from '../src/http-client';
 jest.mock('../src/http-client');
 
 describe('The Client class', () => {
-  test('should throw an error if there is no given baseURL', function() {
-    expect(() => new Client()).toThrow(/baseURL is required/);
+  describe('The constructor', () => {
+    test('should throw an error if there is no given baseURL', () => {
+      expect(() => new Client()).toThrow(/baseURL is required/);
+    });
+
+    test('should pass the given auth param when initializing http client', () => {
+      const config = {
+        baseURL: 'http://esn/api',
+        auth: {
+          type: 'basic',
+          username: 'test',
+          password: 'secret'
+        }
+      };
+
+      httpClient.mockResolvedValue();
+
+      new Client(config); // eslint-disable-line
+
+      expect(httpClient).toHaveBeenCalledWith(config);
+    });
   });
 
-  test('should pass the given auth param when initializing http client', () => {
-    const config = {
-      baseURL: 'http://esn/api',
-      auth: {
-        type: 'basic',
-        username: 'test',
-        password: 'secret'
-      }
-    };
+  describe('The api method', () => {
+    test('should send request with credentials by default', (done) => {
+      const client = new Client({ baseURL: 'http://esn/api' });
+      const config = { foo: 'bar' };
 
-    httpClient.mockResolvedValue();
+      client.httpClient = jest.fn().mockResolvedValue(Promise.resolve({}));
+      client.api(config)
+        .then(() => {
+          expect(client.httpClient).toHaveBeenCalledWith({
+            foo: 'bar',
+            withCredentials: true
+          });
+          done();
+        })
+        .catch((err) => done(err || new Error('should resolve')));
+    });
 
-    new Client(config); // eslint-disable-line
+    test('should send request without credentials if it is intended', (done) => {
+      const client = new Client({ baseURL: 'http://esn/api' });
+      const config = { foo: 'bar', withCredentials: false };
 
-    expect(httpClient).toHaveBeenCalledWith(config);
-  });
-
-  test('should send request with credentials by default', function(done) {
-    const client = new Client({ baseURL: 'http://esn/api' });
-    const config = { foo: 'bar' };
-
-    client.httpClient = jest.fn().mockResolvedValue(Promise.resolve({}));
-    client.api(config)
-      .then(() => {
-        expect(client.httpClient).toHaveBeenCalledWith({
-          foo: 'bar',
-          withCredentials: true
-        });
-        done();
-      })
-      .catch((err) => done(err || new Error('should resolve')));
-  });
-
-  test('should send request without credentials if it is intended', function(done) {
-    const client = new Client({ baseURL: 'http://esn/api' });
-    const config = { foo: 'bar', withCredentials: false };
-
-    client.httpClient = jest.fn().mockResolvedValue(Promise.resolve({}));
-    client.api(config)
-      .then(() => {
-        expect(client.httpClient).toHaveBeenCalledWith(config);
-        done();
-      })
-      .catch((err) => done(err || new Error('should resolve')));
+      client.httpClient = jest.fn().mockResolvedValue(Promise.resolve({}));
+      client.api(config)
+        .then(() => {
+          expect(client.httpClient).toHaveBeenCalledWith(config);
+          done();
+        })
+        .catch((err) => done(err || new Error('should resolve')));
+    });
   });
 });

--- a/test/Client.spec.js
+++ b/test/Client.spec.js
@@ -56,5 +56,19 @@ describe('The Client class', () => {
         })
         .catch((err) => done(err || new Error('should resolve')));
     });
+
+    test('should send request and return the body data from the response', (done) => {
+      const client = new Client({ baseURL: 'http://esn/api' });
+      const response = { data: { foo: 'bar' } };
+
+      client.httpClient = jest.fn().mockResolvedValue(Promise.resolve(response));
+      client.api()
+        .then((bodyData) => {
+          expect(client.httpClient).toHaveBeenCalledWith({ withCredentials: true });
+          expect(bodyData).toEqual(response.data);
+          done();
+        })
+        .catch((err) => done(err || new Error('should resolve')));
+    });
   });
 });

--- a/test/Client.spec.js
+++ b/test/Client.spec.js
@@ -1,7 +1,14 @@
+import CustomPromise from 'promise-polyfill';
 import { Client } from '../src';
 import httpClient from '../src/http-client';
 
 jest.mock('../src/http-client');
+
+const customPromise = function(callback) {
+  return new CustomPromise((resolve, reject) => {
+    callback(resolve, reject);
+  });
+};
 
 describe('The Client class', () => {
   describe('The constructor', () => {
@@ -25,50 +32,126 @@ describe('The Client class', () => {
 
       expect(httpClient).toHaveBeenCalledWith(config);
     });
+
+    test('should allow passing a custom Promise object when constructing the client', () => {
+      const config = {
+        baseURL: 'http://esn/api',
+        auth: {
+          type: 'basic',
+          username: 'test',
+          password: 'secret'
+        },
+        customPromise
+      };
+
+      const client = new Client(config);
+
+      expect(client.customPromise).toBe(customPromise);
+    });
   });
 
   describe('The api method', () => {
-    test('should send request with credentials by default', (done) => {
-      const client = new Client({ baseURL: 'http://esn/api' });
-      const config = { foo: 'bar' };
+    describe('when no custom promise object is provided', () => {
+      test('should send request with credentials by default', (done) => {
+        const client = new Client({ baseURL: 'http://esn/api' });
+        const config = { foo: 'bar' };
 
-      client.httpClient = jest.fn().mockResolvedValue(Promise.resolve({}));
-      client.api(config)
-        .then(() => {
-          expect(client.httpClient).toHaveBeenCalledWith({
-            foo: 'bar',
-            withCredentials: true
+        client.httpClient = jest.fn().mockResolvedValue(Promise.resolve({}));
+        client.api(config)
+          .then(() => {
+            expect(client.httpClient).toHaveBeenCalledWith({
+              foo: 'bar',
+              withCredentials: true
+            });
+            done();
+          })
+          .catch((err) => done(err || new Error('should resolve')));
+      });
+
+      test('should send request without credentials if it is intended', (done) => {
+        const client = new Client({ baseURL: 'http://esn/api' });
+        const config = { foo: 'bar', withCredentials: false };
+
+        client.httpClient = jest.fn().mockResolvedValue(Promise.resolve({}));
+        client.api(config)
+          .then(() => {
+            expect(client.httpClient).toHaveBeenCalledWith(config);
+            done();
+          })
+          .catch((err) => done(err || new Error('should resolve')));
+      });
+
+      test('should send request and return the body data from the response', (done) => {
+        const client = new Client({ baseURL: 'http://esn/api' });
+        const response = { data: { foo: 'bar' } };
+
+        client.httpClient = jest.fn().mockResolvedValue(Promise.resolve(response));
+        client.api()
+          .then((bodyData) => {
+            expect(client.httpClient).toHaveBeenCalledWith({ withCredentials: true });
+            expect(bodyData).toEqual(response.data);
+            done();
+          })
+          .catch((err) => done(err || new Error('should resolve')));
+      });
+    });
+
+    describe('when a custom promise object is provided', () => {
+      test('should send request with credentials by default', (done) => {
+        const client = new Client({ baseURL: 'http://esn/api', customPromise });
+        const config = { foo: 'bar' };
+
+        client.httpClient = jest.fn().mockResolvedValue(Promise.resolve({}));
+        client.api(config)
+          .then(() => {
+            expect(client.httpClient).toHaveBeenCalledWith({
+              foo: 'bar',
+              withCredentials: true
+            });
+            done();
+          })
+          .catch((err) => done(err || new Error('should resolve')));
+      });
+
+      test('should send request without credentials if it is intended', (done) => {
+        const client = new Client({ baseURL: 'http://esn/api', customPromise });
+        const config = { foo: 'bar', withCredentials: false };
+
+        client.httpClient = jest.fn().mockResolvedValue(Promise.resolve({}));
+        client.api(config)
+          .then(() => {
+            expect(client.httpClient).toHaveBeenCalledWith(config);
+            done();
+          })
+          .catch((err) => done(err || new Error('should resolve')));
+      });
+
+      test('should send request and return the body data from the response', (done) => {
+        const client = new Client({ baseURL: 'http://esn/api', customPromise });
+        const response = { data: { foo: 'bar' } };
+
+        client.httpClient = jest.fn().mockResolvedValue(Promise.resolve(response));
+        client.api()
+          .then((bodyData) => {
+            expect(client.httpClient).toHaveBeenCalledWith({ withCredentials: true });
+            expect(bodyData).toEqual(response.data);
+            done();
+          })
+          .catch((err) => done(err || new Error('should resolve')));
+      });
+
+      test('should be able to catch an error and reject with the error', (done) => {
+        const client = new Client({ baseURL: 'http://esn/api', customPromise });
+        const error = new Error('Something went wrong!');
+
+        client.httpClient = jest.fn().mockResolvedValue(Promise.reject(error));
+        client.api()
+          .then(done.fail)
+          .catch((err) => {
+            expect(err).toEqual(error);
+            done();
           });
-          done();
-        })
-        .catch((err) => done(err || new Error('should resolve')));
-    });
-
-    test('should send request without credentials if it is intended', (done) => {
-      const client = new Client({ baseURL: 'http://esn/api' });
-      const config = { foo: 'bar', withCredentials: false };
-
-      client.httpClient = jest.fn().mockResolvedValue(Promise.resolve({}));
-      client.api(config)
-        .then(() => {
-          expect(client.httpClient).toHaveBeenCalledWith(config);
-          done();
-        })
-        .catch((err) => done(err || new Error('should resolve')));
-    });
-
-    test('should send request and return the body data from the response', (done) => {
-      const client = new Client({ baseURL: 'http://esn/api' });
-      const response = { data: { foo: 'bar' } };
-
-      client.httpClient = jest.fn().mockResolvedValue(Promise.resolve(response));
-      client.api()
-        .then((bodyData) => {
-          expect(client.httpClient).toHaveBeenCalledWith({ withCredentials: true });
-          expect(bodyData).toEqual(response.data);
-          done();
-        })
-        .catch((err) => done(err || new Error('should resolve')));
+      });
     });
   });
 });


### PR DESCRIPTION
Resolves #12.