### PR TITLE
esn-dav-import-client#5: Adjusted the BASE_PATH of DAV Import APIs

### DIFF
--- a/src/api/dav-import.js
+++ b/src/api/dav-import.js
@@ -1,4 +1,4 @@
-const BASE_PATH = '/import';
+const BASE_PATH = '/linagora.esn.dav.import/api/import';
 
 export default function(client) {
   return {

--- a/test/api/dav-import.spec.js
+++ b/test/api/dav-import.spec.js
@@ -13,7 +13,7 @@ describe('The dav import APIs', () => {
       const file = { foo: 'bar' };
       const target = '/address/book/path';
 
-      setup.mockAdapter.onPost('/import').reply(202);
+      setup.mockAdapter.onPost('/linagora.esn.dav.import/api/import').reply(202);
       api.importFromFile(file, target)
         .then(() => done())
         .catch((err) => done(err || new Error('should resolve')));


### PR DESCRIPTION
Partially resolves https://github.com/OpenPaaS-Suite/esn-dav-import-client/issues/5. Please also refer to https://github.com/OpenPaaS-Suite/esn-dav-import-client/pull/6.